### PR TITLE
Added: code-oss icon symlinks

### DIFF
--- a/Newaita-dark/apps/128/code-oss.svg
+++ b/Newaita-dark/apps/128/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/16/code-oss.svg
+++ b/Newaita-dark/apps/16/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/22/code-oss.svg
+++ b/Newaita-dark/apps/22/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/24/code-oss.svg
+++ b/Newaita-dark/apps/24/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/256/code-oss.svg
+++ b/Newaita-dark/apps/256/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/32/code-oss.svg
+++ b/Newaita-dark/apps/32/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/48/code-oss.svg
+++ b/Newaita-dark/apps/48/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/64/code-oss.svg
+++ b/Newaita-dark/apps/64/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita-dark/apps/scalable/code-oss.svg
+++ b/Newaita-dark/apps/scalable/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/128/code-oss.svg
+++ b/Newaita/apps/128/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/16/code-oss.svg
+++ b/Newaita/apps/16/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/22/code-oss.svg
+++ b/Newaita/apps/22/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/24/code-oss.svg
+++ b/Newaita/apps/24/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/256/code-oss.svg
+++ b/Newaita/apps/256/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/32/code-oss.svg
+++ b/Newaita/apps/32/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/48/code-oss.svg
+++ b/Newaita/apps/48/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/64/code-oss.svg
+++ b/Newaita/apps/64/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg

--- a/Newaita/apps/scalable/code-oss.svg
+++ b/Newaita/apps/scalable/code-oss.svg
@@ -1,0 +1,1 @@
+visual-studio-code.svg


### PR DESCRIPTION
Desktop entry in Arch `community/code` package uses `code-oss` icon name.