### PR TITLE
Add symbolic links for app Zoom

### DIFF
--- a/Newaita/apps/16/us.zoom.Zoom.svg
+++ b/Newaita/apps/16/us.zoom.Zoom.svg
@@ -1,0 +1,1 @@
+Zoom.svg

--- a/Newaita/apps/22/us.zoom.Zoom.svg
+++ b/Newaita/apps/22/us.zoom.Zoom.svg
@@ -1,0 +1,1 @@
+Zoom.svg

--- a/Newaita/apps/24/us.zoom.Zoom.svg
+++ b/Newaita/apps/24/us.zoom.Zoom.svg
@@ -1,0 +1,1 @@
+Zoom.svg

--- a/Newaita/apps/32/us.zoom.Zoom.svg
+++ b/Newaita/apps/32/us.zoom.Zoom.svg
@@ -1,0 +1,1 @@
+Zoom.svg

--- a/Newaita/apps/48/us.zoom.Zoom.svg
+++ b/Newaita/apps/48/us.zoom.Zoom.svg
@@ -1,0 +1,1 @@
+Zoom.svg

--- a/Newaita/apps/64/us.zoom.Zoom.svg
+++ b/Newaita/apps/64/us.zoom.Zoom.svg
@@ -1,0 +1,1 @@
+Zoom.svg


### PR DESCRIPTION
Additional links for existing icon. The Desktop file for Zoom from flathub has this Icon line

`Icon=us.zoom.Zoom`

Added symbolic link back to `Zoom.svg`